### PR TITLE
[Speed] Major speed improvement by using RollingCurl and parsing HTML directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,14 @@
     "description": "Install and manage WordPress plugins with Composer",
     "require": {
         "php": ">=5.3.2",
-	    "composer/composer": "1.0.*@dev",
+        "composer/composer": "1.0.*@dev",
         "symfony/console": "*",
-	    "symfony/filesystem":"*"
+        "symfony/filesystem":"*",
+        "chuyskywalker/rolling-curl": "*"
     },
     "autoload": {
         "psr-0": {
-	        "Outlandish": "src/"
+            "Outlandish": "src/"
         }
     }
 }


### PR DESCRIPTION
Two big things: 
1. The tags are now parsed directly from the tags page via the Web interface. This is about twice as fast as using `svn ls`. I currently fetch all `li` items on the page and I doubt they will update their format soon.
2. I added the [https://github.com/chuyskywalker/rolling-curl](RollingCurl) library which is a wrapper around [http://www.php.net/manual/en/function.curl-multi-init.php](PHP curl_multi). By default, it maintains 10 concurrent connections, but this is overridable via the `concurrent` option.

I saw dramatic improvements on my computer, using 10 connections, it was almost 15 times faster (including the 50% gain by directly parsing HTML).
