### PR TITLE
[Feature] Trunk version fixes

### DIFF
--- a/src/Outlandish/Wpackagist/BuildCommand.php
+++ b/src/Outlandish/Wpackagist/BuildCommand.php
@@ -75,6 +75,10 @@ class BuildCommand extends Command
 						'homepage' => "http://wordpress.org/extend/plugins/$plugin->name",
 						'uid' => $uid++
 					);
+
+					if ($version == 'trunk') {
+						$package[$version]['time'] = $plugin->last_committed;
+					}
 				}
 
 				$content = json_encode(array('packages' => array($packageName => $package)));


### PR DESCRIPTION
Two small improvements as requested in #18:
- List `trunk` as `dev-trunk`
- Add `time` for `trunk` (since we have it anyway)
