### PR TITLE
fix example for trunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Example composer.json:
 	    ],
 	    "require": {
 	        "aws/aws-sdk-php":"*",
-	        "wpackagist/advanced-custom-fields":"*",
+	        "wpackagist/advanced-custom-fields":"dev-trunk",
 	        "wpackagist/posts-to-posts":">=1.6"
 	    },
 	    "autoload": {


### PR DESCRIPTION
if you specify "*" as the version in the require block composer update will work but composer install won't - it needs 'dev-trunk', so I've updated the docs. 

The website will also need updating.
