### PR TITLE
Split providers by smaller groups

### DIFF
--- a/src/Outlandish/Wpackagist/BuildCommand.php
+++ b/src/Outlandish/Wpackagist/BuildCommand.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Outlandish\Wpackagist\Package\AbstractPackage;
 
 class BuildCommand extends Command
 {
@@ -14,6 +15,36 @@ class BuildCommand extends Command
         $this
                 ->setName('build')
                 ->setDescription('Build package.json from DB');
+    }
+
+    /**
+     * Return a string to split packages in more-or-less even groups
+     * of their last modification. Minimizes groups modifications.
+     *
+     * @return string
+     */
+    protected function getComposerProviderGroup(AbstractPackage $package)
+    {
+        $date = $package->getLastCommited();
+
+        if ($date >= new \DateTime('monday last week')) {
+            return 'this-week';
+        } elseif ($date >= new \DateTime(date('Y') . '-01-01')) {
+            // split current by chunks of 3 months, current month included
+            // past chunks will never be update this year
+            $month = $date->format('n');
+            $month = ceil($month / 3) * 3;
+            $month = str_pad($month, 2, '0', STR_PAD_LEFT);
+
+            return $date->format('Y-') . $month;
+        } elseif ($date >= new \DateTime('2011-01-01')) {
+            // split by years, limit at 2011 so we never update 'old' again
+            return $date->format('Y');
+        } else {
+            // 2010 and older is about 2M, which is manageable
+            // Still some packages ? Probably junk/errors
+            return 'old';
+        }
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -50,11 +81,14 @@ class BuildCommand extends Command
                 $content = json_encode(array('packages' => array($packageName => $packageData)));
                 $sha256 = hash('sha256', $content);
                 file_put_contents("$basePath$packageName\$$sha256.json", $content);
-                $providers[$package->getComposerProviderGroup()][$packageName] = array(
+                $providers[$this->getComposerProviderGroup($package)][$packageName] = array(
                     'sha256' => $sha256
                 );
             }
         }
+
+        $table = $this->getHelper('table');
+        $table->setHeaders(array('provider', 'packages', 'size'));
 
         $providerIncludes = array();
         foreach ($providers as $providerGroup => $providers) {
@@ -66,8 +100,14 @@ class BuildCommand extends Command
                 'sha256' => $sha256
             );
 
-            $output->writeln('Generated packages for '.$providerGroup);
+            $table->addRow(array(
+                $providerGroup,
+                count($providers),
+                round(filesize("{$basePath}providers-$providerGroup\$$sha256.json") / 1024)
+            ));
         }
+
+        $table->render($output);
 
         $content = json_encode(array(
             'packages' => array(),

--- a/src/Outlandish/Wpackagist/Package/AbstractPackage.php
+++ b/src/Outlandish/Wpackagist/Package/AbstractPackage.php
@@ -96,27 +96,6 @@ abstract class AbstractPackage
     }
 
     /**
-     * Ex: themes-2014
-     * @return string
-     */
-    public function getComposerProviderGroup()
-    {
-        $date = $this->getLastCommited();
-
-        if ($date > new \DateTime('last monday')) {
-            return 'last-week';
-        } elseif ($date > new \DateTime('first day of 2 months ago')) {
-            return 'last-2-months';
-        } elseif ($date > new \DateTime('first day of this year')) {
-            return 'this-year';
-        } elseif ($date > new \DateTime('first day of last year')) {
-            return 'last-year';
-        } else {
-            return 'old';
-        }
-    }
-
-    /**
      * @return string "wpackagist-TYPE/PACKAGE"
      */
     public function getPackageName()


### PR DESCRIPTION
There are 3 problems with the current separation (the one I did in #29):
1. The providers get update too frequently.
2. Old is too big, if your connection is not fast enough, composer will timeout and fail horribly.
3. There is actually a bug, last-year is not really last year.

Problem 2 is the reason why I’m doing this. It is especially painful if wpackagist’s server gets overloaded.

Before:

```
+---------------+----------+---------+
| provider      | packages | size    |
+---------------+----------+---------+
| old           | 41388    | 4.5 MiB |
| last-year     | 19803    | 2.2 MiB |
| last-2-months | 9840     | 1.1 MiB |
| last-week     | 1054     | 117 KiB |
+---------------+----------+---------+
```

After:

```
+-----------+----------+---------+
| provider  | packages | size    |
+-----------+----------+---------+
| 2013      | 11216    | 1.2 MiB |
| 2012      | 9145     | 1.0 MiB |
| old       | 15046    | 1.6 MiB |
| 2011      | 7317     | 820 KiB |
| 2014-06   | 5355     | 603 KiB |
| 2014-09   | 9241     | 1.0 MiB |
| 2014-03   | 3861     | 433 KiB |
| 2014-12   | 8211     | 927 KiB |
| this-week | 2693     | 303 KiB |
+-----------+----------+---------+
```
