### PR TITLE
Enable debug only locally

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -8,8 +8,13 @@ use Symfony\Component\HttpFoundation\Response;
 use Pagerfanta\Pagerfanta;
 use Pagerfanta\Adapter\DoctrineDbalSingleTableAdapter;
 
-// Uncomment next line to activate the debug
-$app['debug'] = true;
+// Enable debug only locally
+if (!isset($_SERVER['HTTP_CLIENT_IP'])
+    || !isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+    || in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
+) {
+    $app['debug'] = true;
+}
 
 ///////////////////
 // CONFIGURATION //


### PR DESCRIPTION
Extracted from the silex skeleton: https://github.com/silexphp/Silex-Skeleton/blob/master/web/index_dev.php

I just inverted the condition to allow the debug to be set to true only in development, without having to forget to comment it when deploying.