### PR TITLE
Add link to Wordpress.com Plugin Directory

### DIFF
--- a/web/templates/search.twig
+++ b/web/templates/search.twig
@@ -28,7 +28,7 @@
                         {{ package['class_name'] | format_category }}
                     </td>
                     <td data-name="{{ package['name'] | e }}">
-                        {{ package['name'] | e }}
+                        <a href="https://wordpress.org/plugins/{{ package['name'] | e }}/" target="_blank">{{ package['name'] | e }}</a>
                     </td>
                     <td>
                         {{ package['last_committed'] | default('Not Committed') }}

--- a/web/templates/search.twig
+++ b/web/templates/search.twig
@@ -28,7 +28,7 @@
                         {{ package['class_name'] | format_category }}
                     </td>
                     <td data-name="{{ package['name'] | e }}">
-                        <a href="https://wordpress.org/plugins/{{ package['name'] | e }}/" target="_blank">{{ package['name'] | e }}</a>
+                        <a href="https://wordpress.org/{{package['class_name'] | format_category | lower}}s/{{ package['name'] | e }}/" target="_blank">{{ package['name'] | e }}</a>
                     </td>
                     <td>
                         {{ package['last_committed'] | default('Not Committed') }}


### PR DESCRIPTION
This PR makes the package name link to the plugin page on Wordpress.com, eg. `google-sitemap-generator` links to https://wordpress.org/plugins/google-sitemap-generator/