### PR TITLE
Fix issue with search

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -130,7 +130,7 @@ $app->get('/search', function (Request $request) use ($app, $searchForm) {
 
     if (!empty($query)) {
         $queryBuilder
-            ->andWhere('name LIKE :name')
+            ->where('name LIKE :name')
             ->addOrderBy('name LIKE :order', 'DESC')
             ->addOrderBy('name', 'ASC')
             ->setParameter(':name', "%{$query}%")


### PR DESCRIPTION
I was getting an error when searching. It seems this was just a case of the wrong method to use in Doctrine. (`andWhere` instead of `where`) which resulted in broken MySQL output. I can't reproduce this on https://wpackagist.org/ though, maybe you are running a newer version than on GitHub, or you have older versions of PHP/SQLite that somehow make this problem not show up.

The error:  

```
PDOException in Connection.php line 625: SQLSTATE[HY000]: General error: 1 near ")": syntax error

    in Connection.php line 625
    at PDO->prepare('SELECT * FROM packages p WHERE () ORDER BY is_active DESC, name LIKE :order DESC, name ASC LIMIT 30 OFFSET 0') in Connection.php line 625
    at Connection->executeQuery('SELECT * FROM packages p WHERE () ORDER BY is_active DESC, name LIKE :order DESC, name ASC LIMIT 30 OFFSET 0', array(':name' => '%english-wp-admin%', ':order' => 'english-wp-admin%'), array()) in QueryBuilder.php line 185
    at QueryBuilder->execute() in DoctrineDbalAdapter.php line 73
    at DoctrineDbalAdapter->getSlice('0', '30') in Pagerfanta.php line 319
    at Pagerfanta->getCurrentPageResultsFromAdapter() in Pagerfanta.php line 303
    at Pagerfanta->getCurrentPageResults() in index.php line 150
    at {closure}(object(Request))
    at call_user_func_array(object(Closure), array(object(Request))) in HttpKernel.php line 145
    at HttpKernel->handleRaw(object(Request), '1') in HttpKernel.php line 66
    at HttpKernel->handle(object(Request), '1', true) in Application.php line 538
    at Application->handle(object(Request)) in Application.php line 515
    at Application->run() in index.php line 166
```