### PR TITLE
Refetch packages if they were last fetched within two hours of their most recent commit

### DIFF
--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -52,7 +52,7 @@ class UpdateCommand extends Command
 
         $update = $db->prepare(
             'UPDATE packages SET last_fetched = datetime("now"), versions = :json, is_active = 1
-            WHERE class_name = :class_name AND name = :name'
+            WHERE class_name = :class_name AND name = :name AND versions != :json'
         );
         $deactivate = $db->prepare('UPDATE packages SET last_fetched = datetime("now"), is_active = 0 WHERE class_name = :class_name AND name = :name');
 

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -52,7 +52,7 @@ class UpdateCommand extends Command
 
         $update = $db->prepare(
             'UPDATE packages SET last_fetched = datetime("now"), versions = :json, is_active = 1
-            WHERE class_name = :class_name AND name = :name AND versions != :json'
+            WHERE class_name = :class_name AND name = :name'
         );
         $deactivate = $db->prepare('UPDATE packages SET last_fetched = datetime("now"), is_active = 0 WHERE class_name = :class_name AND name = :name');
 
@@ -61,7 +61,7 @@ class UpdateCommand extends Command
         $packages = $db->query('
             SELECT * FROM packages
             WHERE last_fetched IS NULL
-            OR last_fetched < last_committed
+            OR last_fetched < datetime(last_committed, "+2 hours")
             OR (is_active = 0 AND last_committed > date("now", "-90 days") AND last_fetched < datetime("now", "-7 days"))
         ')->fetchAll(\PDO::FETCH_CLASS | \PDO::FETCH_CLASSTYPE);
 


### PR DESCRIPTION
@tamlyn I've been trying to diagnose the bug where some plugins don't have new versions. Looking in the database at a couple of examples, I find packages where `last_committed < last_fetched`, but the newest versions are missing.

My theory is that we query the wordpress.org API too soon after the SVN repo is updated, so the new versions appear in SVN but not in the API response.

The change in this PR is to only update `last_fetched` if the `versions` JSON changes.

Does this make sense to you?