### PR TITLE
Fix update issue with dev-trunk packages

### DIFF
--- a/src/Package/Plugin.php
+++ b/src/Package/Plugin.php
@@ -26,8 +26,11 @@ class Plugin extends AbstractPackage
 
     public function getDownloadUrl($version)
     {
-        $filename = $this->versions[$version] == 'trunk' ? $this->getName() : $this->getName().'.'.$version;
+        $isTrunk = $this->versions[$version] === 'trunk';
 
-        return "https://downloads.wordpress.org/plugin/$filename.zip";
+        //Assemble file name and append ?timestamp= variable to the trunk version to avoid Composer cache when plugin/theme author only updates the trunk
+        $filename = ($isTrunk ? $this->getName() : $this->getName().'.'.$version) . '.zip' . ($isTrunk ? '?timestamp=' . urlencode($this->last_committed->format('U')) : '');
+
+        return "https://downloads.wordpress.org/plugin/{$filename}";
     }
 }


### PR DESCRIPTION
There is an issue when using `dev-trunk` or requiring plugins that do not have a tagged version.

WordPress always puts such releases under the same URL even if it has been updated. But Composer has a URL cache, so it does not know that there is a new version available to download and will fetch from cache. 

For example, the URL might look like this:

```
https://downloads.wordpress.org/plugin/wp-core-media-widgets.zip
```

Because the URL never changes, running `composer install` will result in the packages being loaded from cache if it has downloaded an older version previously.

This PR introduces a change to how `dev-trunk`  URLs are handled. They will now have the `last_commited` timestamp to bypass the Composer cache. For example:

```
https://downloads.wordpress.org/plugin/wp-core-media-widgets.zip?timestamp=1490130621
```