### PR TITLE
Added installer paths

### DIFF
--- a/web/templates/index.twig
+++ b/web/templates/index.twig
@@ -52,6 +52,11 @@
         "psr-0": {
             "Acme": "src/"
         }
+    },
+    "extra": {
+        "installer-paths": {
+            "wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
+        }
     }
 }</pre>
 


### PR DESCRIPTION
Added installer-paths to composer.json example

The example is missing the installer paths argument otherwise the plugin gets installed straight into the `vendor` dir.