### PR TITLE
WPK-5 - 12-factor-ify package file location, using `PACKAGE_PATH` env var

### DIFF
--- a/.env
+++ b/.env
@@ -28,4 +28,7 @@ APP_SECRET=replace-with-your-secret
 DATABASE_URL=sqlite:///%kernel.project_dir%/data/packages.sqlite
 ###< doctrine/doctrine-bundle ###
 
+# Deployed envs use an EFS-mounted path so that all instances share data.
+PACKAGE_PATH=/var/www/html/packages
+
 PUBLIC_DIR=web

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .idea
 /data/packages.sqlite
 /vendor
-/web/packages.json
-/web/p
+/packages/*
+!/packages/Readme.md
 
 ###> symfony/framework-bundle ###
 /.env.local

--- a/packages/Readme.md
+++ b/packages/Readme.md
@@ -1,0 +1,1 @@
+Local only – ECS will use an EFS mount.


### PR DESCRIPTION
JSON files are now served via a Symfony route and the source
files need not live in the local filesystem.

This should allow us to fix the build/serve process when deploying
to ECS and using EFS as a shared, persistent file store.