### PR TITLE
Attempt to fetch IP from upstream proxy

### DIFF
--- a/src/Controller/MainController.php
+++ b/src/Controller/MainController.php
@@ -174,7 +174,14 @@ class MainController extends AbstractController
         }
         $safeName = $package['name'];
 
-        $count = $this->getRequestCountByIp($_SERVER['REMOTE_ADDR'], $connection);
+        if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARDED_FOR']) {
+            $splitIp = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+            $userIp  = trim($splitIp[0]);
+        } else {
+            $userIp = $_SERVER['REMOTE_ADDR'];
+        }
+
+        $count = $this->getRequestCountByIp($userIp, $connection);
         if ($count > 10) {
             return new Response('Too many requests. Try again in an hour.', 403);
         }


### PR DESCRIPTION
This should hopefully fix the "Too many requests" errors when people update packages manually.

Symfony can also be configured to support upstream proxies (but you do need to know their IPs), which might be a better long-term solution.
https://symfony.com/doc/current/deployment/proxies.html