### PR TITLE
Allow examples to scroll when overflowing container

### DIFF
--- a/web/assets/css/style.css
+++ b/web/assets/css/style.css
@@ -52,6 +52,10 @@ blockquote, pre {
     background-color: #f2f2f2;
 }
 
+pre {
+    overflow: auto;
+}
+
 #title, .mission {
     margin: 3rem 0;
 }


### PR DESCRIPTION
Currently, the code example overflows its' container. This adds the ability for the container to scroll.

<img src="https://user-images.githubusercontent.com/6947218/94807354-86c9b380-03bd-11eb-9c92-44ae6cb006f4.png" width="500">
