### PR TITLE
Simplify + tidy package type derivation

### DIFF
--- a/src/Twig/PackageExtension.php
+++ b/src/Twig/PackageExtension.php
@@ -10,18 +10,8 @@ class PackageExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('format_category', [$this, 'formatCategory']),
             new TwigFilter('format_versions', [$this, 'formatVersions']),
         ];
-    }
-
-    /**
-     * @param string $category
-     * @return string
-     */
-    public function formatCategory($category): string
-    {
-        return str_replace('Outlandish\Wpackagist\Entity\\', '', $category);
     }
 
     public function formatVersions(?array $versionsIn): array

--- a/web/templates/search.twig
+++ b/web/templates/search.twig
@@ -25,11 +25,11 @@
         <tbody>
             {% for package in currentPageResults %}
                 <tr>
-                    <td data-type="{{ package.type | format_category | lower }}">
-                        {{ package.type | format_category }}
+                    <td data-type="{{ package.type }}">
+                        {{ package.type | capitalize }}
                     </td>
                     <td data-name="{{ package.name | e }}">
-                        <a href="https://wordpress.org/{{package.type | format_category | lower}}s/{{ package.name | e }}/" target="_blank">{{ package.name | e }}</a>
+                        <a href="https://wordpress.org/{{ package.type }}s/{{ package.name | e }}/" target="_blank">{{ package.name | e }}</a>
                     </td>
                     <td>
                         {{ package.lastCommitted ? package.lastCommitted | date : 'Not Committed' }}


### PR DESCRIPTION
We don't need `formatCategory()` via Twig filter now we have Doctrine single table inheritance
mapping the classes