### PR TITLE
Keep provider group naming working across years

### DIFF
--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -286,12 +286,6 @@ abstract class Package
         return $this->providerGroup;
     }
 
-    public function generateProviderGroup()
-    {
-        $this->providerGroup = self::makeComposerProviderGroup($this->lastCommitted);
-        return $this->providerGroup;
-    }
-
     /**
      * Return a string to split packages in more-or-less even groups
      * of their last modification. Minimizes groups modifications.

--- a/src/Entity/PackageRepository.php
+++ b/src/Entity/PackageRepository.php
@@ -41,10 +41,9 @@ class PackageRepository extends EntityRepository
             ->where('p.providerGroup = \'old\'')
             ->andWhere('p.lastCommitted >= :date')
             ->getQuery();
-        foreach ($groups as $key=>$date) {
+        foreach ($groups as $key => $date) {
             $query->execute(['group' => $key, 'date' => $date->format('Y-m-d')]);
         }
-
     }
 
     /**

--- a/src/Service/Update.php
+++ b/src/Service/Update.php
@@ -36,14 +36,15 @@ class Update
         $this->update($logger, $packages);
     }
 
-    public function updateOne(LoggerInterface $logger, string $name)
+    public function updateOne(LoggerInterface $logger, string $name): ?Package
     {
-        /** @var Package $package */
         $package = $this->repo->findOneBy(['name' => $name]);
+
         if ($package) {
             $this->update($logger, [$package]);
-            return $package;
         }
+
+        return $package;
     }
 
     /**

--- a/src/Storage/Filesystem.php
+++ b/src/Storage/Filesystem.php
@@ -64,7 +64,7 @@ final class Filesystem extends PackageStore
         return $this->writeFile($this->getResourcePath($packageName, $hash), $json);
     }
 
-    public function loadAllPackages($packageNames)
+    public function loadAllPackages($packageNames): array
     {
         $json = [];
         $toFind = [];
@@ -91,7 +91,7 @@ final class Filesystem extends PackageStore
         return $json;
     }
 
-    public function loadAllProviders()
+    public function loadAllProviders(): array
     {
         $finder = new Finder();
         $finder->files()->in("{$this->basePath}/{$this->packageDir}")->depth(0);
@@ -115,6 +115,14 @@ final class Filesystem extends PackageStore
         return $this->writeFile($this->getResourcePath($name, $hash), $json);
     }
 
+    public function deactivateProvider(string $name, string $hash): void
+    {
+        $path = $this->getResourcePath($name, $hash);
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
     public function loadRoot(): ?string
     {
         return $this->readFile("{$this->basePath}/packages.json");
@@ -135,6 +143,4 @@ final class Filesystem extends PackageStore
             $this->packageDir = 'p';
         }
     }
-
-
 }

--- a/src/Storage/PackageStore.php
+++ b/src/Storage/PackageStore.php
@@ -27,12 +27,12 @@ abstract class PackageStore
      * @param string[] $packageNames
      * @return string[]
      */
-    abstract public function loadAllPackages(array $packageNames);
+    abstract public function loadAllPackages(array $packageNames): array;
 
     /**
      * @return string[]
      */
-    abstract public function loadAllProviders();
+    abstract public function loadAllProviders(): array;
 
     /**
      * @param string $packageName
@@ -49,6 +49,14 @@ abstract class PackageStore
      * @return bool Success or failure.
      */
     abstract public function saveProvider(string $name, string $hash, string $json): bool;
+
+    /**
+     * Mark a provider group as non-latest or delete it.
+     *
+     * @param string $name  Provider group name
+     * @param string $hash  SHA-256 content hash
+     */
+    abstract public function deactivateProvider(string $name, string $hash): void;
 
     /**
      * @param string $json


### PR DESCRIPTION
* Remove smaller provider groups from past years from `root` on update, fixes #381
* Deactivate individual provider groups too – this should ensure command outputs are consistent with `root` data and avoid any more serious unforeseen issues from the different references to groups going out of sync
* Related tidying