### PR TITLE
add: Support `composer/installers:~2.0`

### DIFF
--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -226,7 +226,7 @@ abstract class Package
         }
 
         if ($type = $this->getComposerType()) {
-            $package['require']['composer/installers'] = '~1.0';
+            $package['require']['composer/installers'] = '~1.0 || ~2.0';
             $package['type'] = $type;
         }
 


### PR DESCRIPTION
Adds support for the `composer/installers` 2.x series, in addition to the 1.x series. This will allow folks to use plugins/themes via wpackagist even if another library requires `composer/installers` @ 2.x.

There are no WordPress-related breaking changes in the 2.x series, per [the changelog](https://github.com/composer/installers/releases/tag/v2.0.0).