### PR TITLE
Allow updates to minor versions of `composer/installers`

### DIFF
--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -226,7 +226,7 @@ abstract class Package
         }
 
         if ($type = $this->getComposerType()) {
-            $package['require']['composer/installers'] = '~1.0 || ~2.0';
+            $package['require']['composer/installers'] = '^1.0 || ^2.0';
             $package['type'] = $type;
         }
 


### PR DESCRIPTION
In #420, support for `composer/installers` `v2` has been introduced. However, the constraints `~1.0 || ~2.0` don't match minor updates of `composer/installers`, e.g. [`1.12.0`](https://github.com/composer/installers/releases/tag/v1.12.0) or `2.1.0`. See https://jubianchi.github.io/semver-check/#/~1.0%20||%20~2.0/1.12.0.

This PR fixes it by replacing the tilde constraint with a caret constraint, similar to https://github.com/Rarst/release-belt/pull/46.