### PR TITLE
#442 – fix custom `RequestRepository` constructor

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,6 +15,8 @@ services:
                             # fetching services directly from the container via $container->get() won't work.
                             # The best practice is to be explicit about your dependencies anyway.
 
+    Outlandish\Wpackagist\Entity\RequestRepository: ~
+
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     Outlandish\Wpackagist\:


### PR DESCRIPTION
Without this change, `ContainerRepositoryFactory` crashes passing only 2 args
to the repo.

Simply listing the class – which was previously excluded from auto-DI setup by the `exclude` rule below – is enough to get it the correct args because we have `autowire` on by default.