### PR TITLE
#442 – fix `MainController::update()`'s use of `RequestRepository` properly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,10 @@
         "platform": {
             "php": "7.2.24"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "minimum-stability": "stable",
     "require": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,7 +15,14 @@ services:
                             # fetching services directly from the container via $container->get() won't work.
                             # The best practice is to be explicit about your dependencies anyway.
 
-    Outlandish\Wpackagist\Entity\RequestRepository: ~
+    request_metadata:
+        class: Doctrine\ORM\Mapping\ClassMetadata
+        arguments:
+            $entityName: Outlandish\Wpackagist\Entity\Request
+
+    Outlandish\Wpackagist\Entity\RequestRepository:
+        arguments:
+            $class: '@request_metadata'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Controller/MainController.php
+++ b/src/Controller/MainController.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\QueryBuilder;
 use Outlandish\Wpackagist\Entity\Package;
 use Outlandish\Wpackagist\Entity\PackageRepository;
 use Outlandish\Wpackagist\Entity\Plugin;
+use Outlandish\Wpackagist\Entity\RequestRepository;
 use Outlandish\Wpackagist\Entity\Theme;
 use Outlandish\Wpackagist\Service;
 use Pagerfanta\Doctrine\ORM\QueryAdapter;
@@ -26,7 +27,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
-use Outlandish\Wpackagist\Entity\Request as RequestLog;
 use Outlandish\Wpackagist\Storage;
 
 class MainController extends AbstractController
@@ -35,12 +35,18 @@ class MainController extends AbstractController
     private $formFactory;
     /** @var FormInterface|null */
     private $form;
+    /** @var RequestRepository */
+    private $requestRepository;
     /** @var Storage\PackageStore */
     private $storage;
 
-    public function __construct(FormFactoryInterface $formFactory, Storage\PackageStore $storage)
-    {
+    public function __construct(
+        FormFactoryInterface $formFactory,
+        RequestRepository $requestRepository,
+        Storage\PackageStore $storage
+    ) {
         $this->formFactory = $formFactory;
+        $this->requestRepository = $requestRepository;
         $this->storage = $storage;
     }
 
@@ -204,8 +210,7 @@ class MainController extends AbstractController
             return new Response('Not Found',404);
         }
 
-        $requestCount = $entityManager->getRepository(RequestLog::class)
-            ->getRequestCountByIp($request->getClientIp(), 0);
+        $requestCount = $this->requestRepository->getRequestCountByIp($request->getClientIp(), 0);
         if ($requestCount > 5) {
             return new Response('Too many requests. Try again in an hour.', 403);
         }

--- a/src/Entity/RequestRepository.php
+++ b/src/Entity/RequestRepository.php
@@ -10,6 +10,11 @@ use Doctrine\ORM\QueryBuilder;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
+/**
+ * This repo uses a custom constructor so it can directly log record contention edge cases. For this reason it is
+ * declared as a service in `services.yaml` and you cannot use `EntityManagerInterface::getRepository()` to retrieve
+ * it. You should instead inject it directly with DI instead.
+ */
 class RequestRepository extends EntityRepository
 {
     /** @var LoggerInterface */


### PR DESCRIPTION
Including fixing the new service definition and explaining what's going on
in the repo class.