### PR TITLE
fix: update monolog.yaml so that migrate-db.sh will execute

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -7,7 +7,6 @@ monolog:
             level: info
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             channels: ["!deprecation"]
-            excluded_http_codes: [404]
         stream:
             type: stream
             path: "php://stdout"


### PR DESCRIPTION
Upon following the directions to set up the Docker container, `migrate-db.sh` errors out as follows:

```
> docker-compose run --rm cron deploy/migrate-db.sh
[+] Running 1/0
 - Container wpackagist-db-1  Running                                                                              0.0s
[+] Running 1/1
 - Container wpackagist-cron-1  Started                                                                            0.9s
Running DB migrations...

In BaseNode.php line 469:

  Invalid configuration for path "monolog.handlers.main": You can only use excluded_http_codes/excluded_404s with a F
  ingersCrossedHandler definition


In ExprBuilder.php line 187:

  You can only use excluded_http_codes/excluded_404s with a FingersCrossedHandler definition


2022-05-13T15:45:30+00:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "BabDev\PagerfantaBundle\BabDevPagerfantaBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```

I'm ignoring the deprecation warning.  

This commit drops the 404 exclusion, allowing the command to proceed. I'm not familiar with monolog configurations but this may be related: https://github.com/symfony/monolog-bundle/issues/309.
