### PR TITLE
fix: better ordering for exact search matches

### DIFF
--- a/web/templates/searchbar.twig
+++ b/web/templates/searchbar.twig
@@ -11,9 +11,6 @@
             <div class="small-6 columns">
                 {{ form_widget(searchForm.type) }}
             </div>
-            {#<div class="small-3 columns">
-                {{ form_widget(searchForm.active_only) }}
-            </div>#}
             <div class="small-6 columns">
                 {{ form_widget(searchForm.search, { 'label': 'Search »','attr': {'class': 'primary-color postfix'}}) }}
             </div>


### PR DESCRIPTION
Previously, the logic would not capture exact matches (e.g., if you search for "woocommerce" you would get 130 pages of results but it doesn't look like it actually includes the exact match).  This is because it was doing a LIKE on "%woocommerce%" so not including the term itself.

Now, we explicitly check for that term in the beginning, middle, end of the results as well as for an exact match.  In addition, we have a smarter ordering where any exact match is at least listed first.  So now you don't have to scroll through hundreds of pages.

Also, drop the apparently-obsolete "active_only" parameter from search as it wasn't used anymore.