### PR TITLE
Composer2: available-package-patterns

### DIFF
--- a/src/Service/Builder.php
+++ b/src/Service/Builder.php
@@ -81,6 +81,7 @@ class Builder
             'packages' => [],
             'providers-url' => '/' . $providerFormat,
             'provider-includes' => $includes,
+            'available-package-patterns' => ['wpackagist-plugin/*', 'wpackagist-theme/*'],
         ]);
         $this->storage->saveRoot($content);
     }


### PR DESCRIPTION
Composer 2 introduced a few new properties that can be added to the packages.json response, among others `available-packages` or `available-package-patterns` see [Composer upgrade documentation](https://github.com/composer/composer/blob/main/UPGRADE-2.0.md#metadata-url).

Setting either of them allows anyone using the Composer repository to skip fetching the provider files if the required packages do not match the defined names/patterns, resulting in less request against WordPress Packagist. 