### PR TITLE
Reduce on-demand update blips

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ date (trying to keep them roughly the same size), and contain references to indi
 Each package has its own JSON file detailing its versions; these can be found in
 https://wpackagist.org/p/wpackagist-{theme|plugin}/{package-name-and-hash}.json.
 
+### Version format limitations
+
+Currently, Wpackagist can only process packages with up to 4 parts in their version numbers, in line with
+the internal handling of Composer v1.x.
+
 ## Running Wpackagist
 
 ### Installing

--- a/src/Controller/MainController.php
+++ b/src/Controller/MainController.php
@@ -210,7 +210,9 @@ class MainController extends AbstractController
         try {
             $this->doSingleUpdate($logger, $builder, $updateService, $storage, $packageRepo, $safeName);
         } catch (UniqueConstraintViolationException $exception) {
-            // Permit exactly 1 retry for now.
+            // Permit exactly 1 retry for now, after a random 0.5 – 3 second wait.
+            usleep(random_int(500000, 3000000));
+            $entityManager->refresh($package);
             $this->doSingleUpdate($logger, $builder, $updateService, $storage, $packageRepo, $safeName);
         }
 

--- a/web/assets/css/style.css
+++ b/web/assets/css/style.css
@@ -84,6 +84,17 @@ button:hover, button:focus, .button:hover, .button:focus {
     text-decoration: none;
 }
 
+button[disabled],
+.button[disabled],
+button[disabled]:focus,
+.button[disabled]:focus,
+button[disabled]:hover,
+.button[disabled]:hover {
+    background-color: #bbb;
+    border-color: #000;
+    color: #fff;
+}
+
 .search-result__refresh-form {
     margin: 0;
 }

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -1,4 +1,9 @@
 $(document).ready(function () {
+    $('.search-result__refresh-form').on('submit', function (event) {
+        // Disable refresh buttons while refreshing to prevent double submit crashes.
+        $('.search-result__refresh-button').prop('disabled', true);
+    });
+
     //click on a version sug to display an info box row
     $('.js-version').on('click', function (event) {
         event.preventDefault();


### PR DESCRIPTION
* [Try to make ad-hoc update calls more likely to succeed in multi-request edge cases](https://github.com/outlandishideas/wpackagist/commit/bbad4707c9a0ca441e993cfc16a1b2d0107161ea)
* [Lock refresh buttons; reduce accidental doubled-up package update calls](https://github.com/outlandishideas/wpackagist/commit/e250df67987526bb96c5a9e8c3a9635bb2995bfd)