### PR TITLE
Support `BuildCommand` retry if a duplicate constraint is hit

### DIFF
--- a/src/Persistence/RetrySafeEntityManager.php
+++ b/src/Persistence/RetrySafeEntityManager.php
@@ -14,6 +14,9 @@ use Doctrine\ORM\Exception\EntityManagerClosed;
 use Psr\Log\LoggerInterface;
 
 /**
+ * An Entity Manager intended to recover gracefully from closed connection type errors, by swapping in a
+ * fresh underlying EM if necessary to complete an operation.
+ *
  * Adapted from @link https://medium.com/lebouchondigital/thread-safe-business-logic-with-doctrine-f09c633f6554
  * and Mike Litoris's comment on the same.
  *


### PR DESCRIPTION
Move all the main package logic and database persistence into a retryable loop, and automatically recover without an error log up to once per command run.