### PR TITLE
Enable `zlib.output_compression`

### DIFF
--- a/config/php/php.ini
+++ b/config/php/php.ini
@@ -17,3 +17,7 @@ opcache.fast_shutdown = 1
 
 ; Task definition artifacts are immutable on ECS and cache check time is 0 on local -> may as well make tasks faster
 opcache.enable_cli = 1
+
+; Trialling this 25/5/23, as Apache might(?) not have been compression JSON returned from PHP as we wanted
+; without it. We should monitor response times & load and decide whether to keep this.
+zlib.output_compression = 1


### PR DESCRIPTION
With other things unchanged, it looks like this is needed in some circumstances for the JSON output from Symfony routes to be compressed in transit