### PR TITLE
Attempt to recover on single update if EntityManager was closed on find

### DIFF
--- a/src/Persistence/RetrySafeEntityManager.php
+++ b/src/Persistence/RetrySafeEntityManager.php
@@ -52,14 +52,14 @@ class RetrySafeEntityManager extends EntityManagerDecorator
         parent::__construct($this->entityManager);
     }
 
-    public function transactional($callback)
+    public function transactional($func): mixed
     {
         $retries = 0;
         do {
             $this->beginTransaction();
 
             try {
-                $ret = $callback();
+                $ret = $func();
 
                 $this->flush();
                 $this->commit();


### PR DESCRIPTION
It's not really clear to me why the EM is sometimes gone on a small % of these updates.

However the update and persist themselves should already have retries via the `EntityManagerInterface` injection, which already provides an object with a retry-safe version of those methods.

So I _think_ by process of elimination it's likely that the query itself (via a repo method which doesn't auto retry) is likely to be where it crashes.

This PR might help recover if that's right, and at a minimum should give us logs which allow us to confirm or deny that that's where the problem is is/when we get another similar crash.