### PR TITLE
Fix copyable composer package version strings and add a versionlss link

### DIFF
--- a/web/assets/css/style.css
+++ b/web/assets/css/style.css
@@ -1073,6 +1073,19 @@ blockquote cite a {
     color: var(--color-primary);
 }
 
+.results-table .copy-composer-package-name {
+    display: inline;
+    padding: 0;
+    background: none;
+    color: var(--color-primary);
+    border-radius: 0;
+    font-size: var(--text-sm);
+    font-weight: var(--font-regular);
+    text-decoration-line: none;
+    margin-right: var(--spacing-sm);
+    margin-bottom: 0;
+}
+
 /* --------------------------------------------------------------------------
    Status Icons
    -------------------------------------------------------------------------- */

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -94,7 +94,7 @@ $(document).ready(function () {
     function updateCopyField() {
         if (!currentPackageData || !selectedVersion) return;
 
-        var copyString = '"wpackagist-' + currentPackageData.type + '/' + currentPackageData.name + '": "' + selectedVersion + '"';
+        var copyString = '"wpackagist-' + currentPackageData.type + '/' + currentPackageData.name + '":"' + selectedVersion + '"';
         $('#modal-copy-field').val(copyString);
     }
 

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -38,6 +38,42 @@ $(document).ready(function () {
         openModal();
     });
 
+    $('.js-composer-package-name').on('click', function (event) {
+        event.preventDefault();
+
+        var $element = $(this),
+            $parentRow = $element.closest('tr'),
+            clickedVersion = $element.data('version');
+
+        // Get package data from row data attributes
+        currentPackageData = {
+            name: $parentRow.data('package-name'),
+            type: $parentRow.data('package-type'),
+            lastCommitted: $parentRow.data('package-last-committed'),
+            lastFetched: $parentRow.data('package-last-fetched'),
+            isActive: $parentRow.data('package-is-active') === true || $parentRow.data('package-is-active') === 'true',
+            versions: $parentRow.data('package-versions') || []
+        };
+
+        var $link = $(this);
+        var $input = $link.children('input').first();
+
+        $input.select();
+
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText($input.val()).then(function () {
+                $link.children('svg').first().html('<polyline points="20 6 9 17 4 12"></polyline>');
+
+                setTimeout(function () {
+                    $link.children('svg').first().html('<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>');
+                }, 2000);
+            });
+        } else {
+            // Fallback for older browsers
+            document.execCommand('copy');
+        }
+    });
+
     function openModal() {
         if (!currentPackageData) return;
 

--- a/web/templates/search.twig
+++ b/web/templates/search.twig
@@ -71,9 +71,21 @@
                             {{ package.lastFetched ? package.lastFetched | date('M j, Y H:i') : 'Not fetched' }}
                         </td>
                         <td>
+                            {% set showLatest = versions|length > 0 %}
                             {% set hasDevTrunk = 'dev-trunk' in versions %}
                             {% set maxVisible = 3 %}
                             {% set hiddenCount = totalVersions > maxVisible ? totalVersions - maxVisible : 0 %}
+
+                            {# Show version-free copy link first if any version available #}
+                            {% if showLatest %}
+                                <a href="#" data-version='"wpackagist-{{ package.type }}/{{ package.name }}"' class="copy-composer-package-name js-composer-package-name" aria-label="Copy versionless composer package name to clipboard" title="Copy versionless composer package name to clipboard">
+                                        <input type="hidden" value='"wpackagist-{{ package.type }}/{{ package.name }}"' />
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                        </svg>
+                                </a>
+                            {% endif %}
 
                             {# Show dev-trunk first if available #}
                             {% if hasDevTrunk %}


### PR DESCRIPTION
The website redesign (commit 20f5de66) introduced a space which breaks composer commands, which expect no space in a package+version specifier.

This PR:

* Fixes #555 
* Also adds a click-to-copy version less link to the search results at the front of the version list.

Steps to test:

1. pull this branch
1. `docker compose up -d`
1. point your browser at http://localhost:30100/search?q=wordpress-seo&type=# (If you don't have a populated DB, hit the Refresh icon and reload the page)
1. Click the 'copy-to-clipboard' link
1. Paste the result somewhere, which should be `"wpackagist-plugin/wordpress-seo"`